### PR TITLE
Refactor: Revert to a blue and white color scheme.

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,10 +18,10 @@
         }
         
         :root {
-            --primary-blue: #000000; /* Uber Black */
+            --primary-blue: #1F64FF; /* Uber Black */
             --secondary-blue: #FFFFFF; /* Uber White */
             --accent-blue: #F0F0F0; /* Light Gray */
-            --dark-blue: #1F64FF; /* Uber Blue Accent */
+            --dark-blue: #004ADF; /* Uber Blue Accent */
             --success-green: #00D084;
             --warning-orange: #FF9500;
             --error-red: #FF3B30;
@@ -44,11 +44,11 @@
         }
 
         .gradient-bg {
-            background: #000000; /* Solid Black for Hero */
+            background: var(--primary-blue); /* Solid Black for Hero */
         }
 
         .blue-gradient {
-            background: #000000; /* Solid Black */
+            background: var(--primary-blue); /* Solid Black */
         }
 
         .pulse-animation {


### PR DESCRIPTION
This commit updates the color scheme to use blue as the primary color and white as the secondary color, as per your request.

Changes include:
- Modified CSS custom properties:
    - `--primary-blue` changed from black (#000000) to blue (#1F64FF).
    - `--dark-blue` changed from its previous blue to a darker shade (#004ADF).
- Updated background classes (`.gradient-bg`, `.blue-gradient`) to use the new primary blue.